### PR TITLE
Fixed asset JS injection

### DIFF
--- a/shortcodes/MapShortcode.php
+++ b/shortcodes/MapShortcode.php
@@ -14,8 +14,8 @@ class MapShortcode extends Shortcode
         $this->shortcode->getHandlers()->add('google-maps', function(ShortcodeInterface $sc) use ($apikeystring) {
 
             //add assets
-            $this->shortcode->addAssets('js', 'https://maps.googleapis.com/maps/api/js'.$apikeystring);
-            $this->shortcode->addAssets('js', 'plugin://google-maps/js/google-maps.js');
+            $this->grav['assets']->addJs('//maps.googleapis.com/maps/api/js'.$apikeystring);
+            $this->grav['assets']->addJs('plugin://google-maps/js/google-maps.js');
             $hash = $this->shortcode->getId($sc);
             $infowindow = $sc->getContent();
 


### PR DESCRIPTION
The Google Maps API and plugin JS files were not being injected in the latest version of Grav. See documentation here:

[Add JavaScript to the footer](https://learn.getgrav.org/cookbook/general-recipes#add-javascript-to-the-footer)
