### PR TITLE
Moved event subscribers to getSubscribedEvents()

### DIFF
--- a/google-maps.php
+++ b/google-maps.php
@@ -21,27 +21,17 @@ class GoogleMapsPlugin extends Plugin
      */
     public static function getSubscribedEvents()
     {
+        // Don't proceed if we are in the admin plugin
+        if (self::isAdmin()) {
+            return [];
+        }
+		
         return [
-            'onPluginsInitialized' => ['onPluginsInitialized', 0]
+            'onShortcodeHandlers' => ['onShortcodeHandlers', 0],
+            'onTwigTemplatePaths' => ['onTwigTemplatePaths', 0],
         ];
     }
 
-    /**
-     * Initialize the plugin
-     */
-    public function onPluginsInitialized()
-    {
-        // Don't proceed if we are in the admin plugin
-        if ($this->isAdmin()) {
-            return;
-        }
-
-        // Enable the main event we are interested in
-        $this->enable([
-            'onShortcodeHandlers' => ['onShortcodeHandlers', 0],
-            'onTwigTemplatePaths' => ['onTwigTemplatePaths', 0],
-        ]);
-    }
 
     public function onShortcodeHandlers()
     {


### PR DESCRIPTION
I experienced problems with plugin load order that made the google maps plugin init after shortcode-core was initialized and fired it's 'onShortcodeHandlers' event.

Per example in Shortcode UI, this issue is solved by moving the events into getSubscribedEvents().
https://github.com/getgrav/grav-plugin-shortcode-ui/blob/develop/shortcode-ui.php