### PR TITLE
extend shortcode content to a series of markers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,5 +44,19 @@ This is my place
 * `draggable` - if false, prevents the map from being dragged | default true
 * `panControl` - the enabled/disabled state of the pan control. | default true
 * `iconurl` - absolute path to a custom marker icon
+* `content` - if `content=json`, then the optional content is json | default text
 
-the optional wrapped content is the **infowindow** content
+If `content` is not `json`, then the optional wrapped content is the **infowindow** content
+
+If `content=json`, then the wrapped content is interpreted as a json string that defines a series of positions for each marker. The `json` string must be of the form:
+```json
+[
+{"key":"20:53", "lat":  22.42559832, "lng":  114.2123749  },
+{"key":"21:09", "lat":  22.41401143, "lng":  114.21253759  },
+{"key":"21:20", "lat":  22.42327849, "lng":  114.21259051  },
+{"key":"21:42", "lat":  22.44140609, "lng":  114.17303335  }
+]
+```
+* `key` is a string that is placed into the title of the marker (the text appears onMouseOver the marker)
+* `lat` is the latitude
+* `lng` is the lattitude

--- a/js/google-maps.js
+++ b/js/google-maps.js
@@ -8,7 +8,9 @@ jQuery(document).ready(function () {
         var draggable = Boolean($(this).data('draggable'));
         var pancontrol = Boolean($(this).data('pancontrol'));
         var icon = $(this).data('iconurl');
-        var window = $(this).data('infowindow');
+        var infowindow = $(this).data('infowindow');
+        var content = $(this).data('content');
+        var markertitle = $(this).data('markertitle');
 
         var map = new google.maps.Map(this, {
             center: {lat: lat, lng: lng},
@@ -18,24 +20,42 @@ jQuery(document).ready(function () {
             panControl: pancontrol
         });
 
-        var marker = new google.maps.Marker({
-            position: {lat: lat, lng: lng},
-            icon: icon,
-            map: map,
-            animation: google.maps.Animation.DROP,
-            title: 'Hello World!'
-        });
-
-        if (window) {
-            var infowindow = new google.maps.InfoWindow({
-                content: window
+        if (infowindow && content  === 'json') {
+            try {
+                if ( infowindow.length < 1 ) throw 'not an array';
+                for ( i = 0 ; i < infowindow.length; i++) {
+                    var marker = new google.maps.Marker({
+                    position: { lat: infowindow[i].lat, lng: infowindow[i].lng },
+                    map: map,
+                    icon: icon,
+                    title: infowindow[i].key ? infowindow[i].key : ''
+                });
+                }
+            } catch (e) {
+                content = 'text';
+                infowindow +=  e;
+            }
+        }
+        if (content !== 'json') {
+            var marker = new google.maps.Marker({
+                position: {lat: lat, lng: lng},
+                icon: icon,
+                map: map,
+                animation: google.maps.Animation.DROP,
+                title: markertitle
             });
 
-            marker.addListener('click', function () {
-                infowindow.open(map, marker);
-            });
+            if (infowindow) {
+                var infowindow_m = new google.maps.InfoWindow({
+                    content: infowindow
+                });
 
-            infowindow.open(map, marker);
+                marker.addListener('click', function () {
+                    infowindow_m.open(map, marker);
+                });
+
+                infowindow_m.open(map, marker);
+            }
         }
     });
 });

--- a/shortcodes/MapShortcode.php
+++ b/shortcodes/MapShortcode.php
@@ -18,7 +18,12 @@ class MapShortcode extends Shortcode
             $this->grav['assets']->addJs('plugin://google-maps/js/google-maps.js');
             $hash = $this->shortcode->getId($sc);
             $infowindow = $sc->getContent();
-
+            $content = $sc->getParameter('content','text');
+            if ($content==="json") {
+                $infowindow = preg_replace('/\s*\<\/?p\>\s*/i','',$infowindow);
+                $infowindow = preg_replace('/\"/','&quot;',$infowindow);
+            }
+            $infowindow = preg_replace('/\\n/','',$infowindow);
             $output = $this->twig->processTemplate('partials/google-maps.html.twig', [
                 'hash' => $hash,
                 'width' => $sc->getParameter('width', '600px'),
@@ -31,6 +36,8 @@ class MapShortcode extends Shortcode
                 'pancontrol' => $sc->getParameter('pancontrol', true),
                 'iconurl' => $sc->getParameter('iconurl', ''),
                 'infowindow' => $infowindow,
+                'content' => $sc->getParameter('content','text'),
+                'markertitle' => $sc->getParameter('markertitle','Hello World')
             ]);
 
             return $output;

--- a/templates/partials/google-maps.html.twig
+++ b/templates/partials/google-maps.html.twig
@@ -6,5 +6,7 @@
      data-draggable="{{ draggable }}"
      data-pancontrol="{{ pancontrol }}"
      data-iconurl="{{ iconurl }}"
-     data-infowindow="{{ infowindow }}">
+     data-infowindow="{{ infowindow }}"
+     data-content="{{ content }}"
+     data-markertitle="{{ markertitle }}">
 </div>


### PR DESCRIPTION
This extension to the plugin is to provide for a string of markers (I needed to show a path or set of locations, and I wanted to have the time in the marker text).

To keep to the original API, if `content` does not exist, then it defaults to `text` and the shortcode operates as before.

If `content=json` then the content is a json string of marker positions.

Note that 
a) another pull-request allows for an optional marker position different to the centre of the map is a special case of my extension, with only 1 marker shown.  
b) if a different title is required (not the hard coded 'hello world'), this also is a special case of this extension.

However, I have not taken into account if a user wants both an Infowindow and a set of paths.

**Apologies**: I changed the variable 'window' to 'infowindow' and where ambiguous, 'infowindow' to 'infowindow_m'. This was because the syntax highlighter in my editor was indicating that 'window' is a pre-defined name in JS.